### PR TITLE
missing quote fix

### DIFF
--- a/result/Jenkinsfile
+++ b/result/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     }
     stage(test){
       when{
-        changeset "**/result/**
+        changeset "**/result/**"
       }
       steps{
         echo 'Running Unit Tests on results app..'


### PR DESCRIPTION
open/closing quotes that maybe I have accidentally erased when originally setting up... closing the string with `"` should fix it.